### PR TITLE
Profile confirmation tooltip on hover

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,10 @@ app.engine('handlebars', handlebars({
     defaultLayout: 'main',
     partialsDir: path.join(__dirname, 'views/partials'),
     helpers: {
-        moment: require('helper-moment')
+        moment: require('helper-moment'),
+        eq: (v1, v2) => {
+            return v1 === v2;
+        }
     }
 }));
 

--- a/static/app.css
+++ b/static/app.css
@@ -5331,13 +5331,13 @@ main {
     margin: 0 0 1.25rem;
     padding: 1.25rem;
     background: #333;
-    background-image: -webkit-linear-gradient(to bottom right, #cad926, #2644d9);
+    background-image: -webkit-linear-gradient(to bottom right, #85d926, #d97726);
     /* For Chrome 25+ and Safari 6+, iOS 6.1+, Android 4.3+ */
-    background-image: -moz-linear-gradient(to bottom right, #cad926, #2644d9);
+    background-image: -moz-linear-gradient(to bottom right, #85d926, #d97726);
     /* For Firefox 3.6+ */
-    background-image: -o-linear-gradient(to bottom right, #cad926, #2644d9);
+    background-image: -o-linear-gradient(to bottom right, #85d926, #d97726);
     /* For old Opera 11.1+ */
-    background-image: linear-gradient(to bottom right, #cad926, #2644d9);
+    background-image: linear-gradient(to bottom right, #85d926, #d97726);
     /* Standard syntax; must be last */
     color: #fefefe; }
     .main-profile .profile-header label {
@@ -5355,6 +5355,27 @@ main {
         margin: 0; }
       .main-profile .profile-header .profile-header-intro .profile-header-title i {
         padding-right: 10px; }
+      .main-profile .profile-header .profile-header-intro .profile-header-status {
+        display: inline-flex;
+        flex-grow: 1;
+        justify-content: flex-end; }
+        .main-profile .profile-header .profile-header-intro .profile-header-status #profile-head-title-privacy {
+          display: none; }
+        .main-profile .profile-header .profile-header-intro .profile-header-status .profile-head-title-privacy {
+          width: fit-content;
+          justify-self: baseline;
+          margin: 10px;
+          padding: 10px 20px;
+          display: inline-flex;
+          background: #4a4a4a33;
+          border: 1px solid #4a4a4a55;
+          border-radius: 50px; }
+          .main-profile .profile-header .profile-header-intro .profile-header-status .profile-head-title-privacy.hidden {
+            display: none; }
+          .main-profile .profile-header .profile-header-intro .profile-header-status .profile-head-title-privacy strong {
+            padding-left: 5px; }
+          .main-profile .profile-header .profile-header-intro .profile-header-status .profile-head-title-privacy i {
+            padding-left: 5px; }
   @media print, screen and (min-width: 64em) {
     .main-profile .profile-header .profile-header-intro {
       align-items: center;

--- a/static/app.css
+++ b/static/app.css
@@ -5331,13 +5331,13 @@ main {
     margin: 0 0 1.25rem;
     padding: 1.25rem;
     background: #333;
-    background-image: -webkit-linear-gradient(to bottom right, #d926af, #d92647);
+    background-image: -webkit-linear-gradient(to bottom right, #cad926, #2644d9);
     /* For Chrome 25+ and Safari 6+, iOS 6.1+, Android 4.3+ */
-    background-image: -moz-linear-gradient(to bottom right, #d926af, #d92647);
+    background-image: -moz-linear-gradient(to bottom right, #cad926, #2644d9);
     /* For Firefox 3.6+ */
-    background-image: -o-linear-gradient(to bottom right, #d926af, #d92647);
+    background-image: -o-linear-gradient(to bottom right, #cad926, #2644d9);
     /* For old Opera 11.1+ */
-    background-image: linear-gradient(to bottom right, #d926af, #d92647);
+    background-image: linear-gradient(to bottom right, #cad926, #2644d9);
     /* Standard syntax; must be last */
     color: #fefefe; }
     .main-profile .profile-header label {
@@ -5475,6 +5475,9 @@ main {
   .edit-button-animate-in .fas:before {
     animation: 0.5s ease 0s 1 changeToEdit;
     content: "\f058"; }
+
+.has-tip {
+  border-bottom: solid 1px transparent; }
 
 @keyframes slideInFromLeft {
   0% {
@@ -5626,6 +5629,9 @@ main {
           padding: 0 10px; }
       .main-current-ads .current-ads-container .display-ads-ad .display-ads-edit-overlay .ads-edit-body {
         padding: 20px; }
+        .main-current-ads .current-ads-container .display-ads-ad .display-ads-edit-overlay .ads-edit-body .ads-edit-instruments {
+          max-height: 200px;
+          overflow: scroll; }
         .main-current-ads .current-ads-container .display-ads-ad .display-ads-edit-overlay .ads-edit-body .cell {
           padding: 0 10px; }
         .main-current-ads .current-ads-container .display-ads-ad .display-ads-edit-overlay .ads-edit-body label {

--- a/static/js/profile.js
+++ b/static/js/profile.js
@@ -15,7 +15,7 @@ function bindButtons() {
             items: [
                 ['profile-header-title-text', 'edit-title-text', 'artistName', false],
                 ['profile-header-title-loc', 'edit-title-loc', 'zipCode', false],
-                ['profile-head-title-privacy', 'edit-title-privacy-switch', 'privacySwitch', (obj => obj.childNodes[4].checked ? 1 : 0), 'profile-head-title-privacy-value', ['You are currently looking for a spot in a band.', 'You are not currently looking for a spot in a band.']]
+                ['profile-head-title-privacy', 'edit-title-privacy-switch', 'privacySwitch', (() => document.getElementById('privacySwitch').getAttribute('checked') === 'true' ? 1 : 0), 'profile-head-title-privacy-value', ['You are currently looking for a spot in a band.', 'You are not currently looking for a spot in a band.']]
             ]
         },
         about: {
@@ -112,6 +112,9 @@ function bindButtons() {
         }
     }
 
+    function handleText() {
+
+    }
 
     // document.getElementById('submitForm').addEventListener('click', e => {
 }

--- a/static/styles/views/_dashboard.scss
+++ b/static/styles/views/_dashboard.scss
@@ -223,6 +223,11 @@ $delete-red-hover: #e57373;
         .ads-edit-body {
           padding: 20px;
 
+          .ads-edit-instruments {
+            max-height: 200px;
+            overflow: scroll;
+          }
+
           .cell {
             padding: 0 10px;
           }

--- a/static/styles/views/_profile.scss
+++ b/static/styles/views/_profile.scss
@@ -211,3 +211,6 @@ $social-links-underline: #48fe80;
   }
 }
 
+.has-tip {
+  border-bottom: solid 1px transparent;
+}

--- a/static/styles/views/_profile.scss
+++ b/static/styles/views/_profile.scss
@@ -79,6 +79,39 @@ $social-links-underline: #48fe80;
           padding-right: 10px;
         }
       }
+
+      .profile-header-status {
+        display: inline-flex;
+        flex-grow: 1;
+        justify-content: flex-end;
+
+        #profile-head-title-privacy {
+          display: none;
+        }
+
+        .profile-head-title-privacy {
+          width: fit-content;
+          justify-self: baseline;
+          margin: 10px;
+          padding: 10px 20px;
+          display: inline-flex;
+          background: #4a4a4a33;
+          border: 1px solid #4a4a4a55;
+          border-radius: 50px;
+
+          &.hidden {
+            display: none;
+          }
+
+          strong {
+            padding-left: 5px;
+          }
+
+          i {
+            padding-left: 5px;
+          }
+        }
+      }
     }
   }
 

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -31,17 +31,17 @@
                         <input type="number" id="edit-title-loc-input" value="{{profile.ZipCode}}" min="00501" max="99950">
                     </div>
                     <h6>Joined {{moment profile.CreateDate format="MMMM Do, YYYY" }}</h6>
-                    <h6 id="profile-head-title-privacy">You are {{#if profile.LookingForWork}}{{else}}not {{/if}} currently looking for a spot in a band.</h6>
+<!--                    <h6 id="profile-head-title-privacy">You are {{#if profile.LookingForWork}}{{else}}not {{/if}} currently looking for a spot in a band.</h6>-->
                     <input type="hidden" id="profile-head-title-privacy-value" value="{{profile.LookingForWork}}">
                     <div id="edit-title-privacy-switch" class="switch" hidden>
                         <span>Are you currently looking for a spot in a band?</span><br>
                         <span id="switch-privacy-tooltip"
                               data-tooltip class="top"
                               tabindex="2"
-                              title="Switching this {{#if profile.LookingForWork}}off{{else}}on{{/if}} will set your profile to {{#if profile.LookingForWork}}private{{else}}public{{/if}} so it will {{#if profile.LookingForWork}}no longer {{/if}}be viewable by other users."
+                              title="Switching this {{#if (eq profile.LookingForWork 1)}}off{{else}}on{{/if}} will set your profile to {{#if (eq profile.LookingForWork 1)}}private{{else}}public{{/if}} so it will {{#if (eq profile.LookingForWork 1)}}no longer {{/if}}be viewable by other users."
                               data-position="bottom"
                               data-alignment="left">
-                            <input class="switch-input" id="privacySwitch" type="checkbox" name="privacySwitch" {{#if profile.LookingForWork}}checked{{/if}}>
+                            <input class="switch-input" id="privacySwitch" type="checkbox" name="privacySwitch" {{#if (eq profile.LookingForWork 1)}}checked="true"{{/if}}>
                             <label class="switch-paddle" for="privacySwitch">
                                 <h6 class="show-for-sr">Are you currently looking for a spot in a band?</h6>
                             </label>
@@ -49,9 +49,15 @@
                         <script type="text/javascript">
                             let ps = document.getElementById('privacySwitch');
                             ps.addEventListener('click', () => {
-                                console.log('privacySwitch', ps);
-                                console.log('privacySwitch clicked! checked ? ', ps.getAttribute('checked'));
-                                ps.setAttribute('checked', ps.getAttribute('checked') ? false : true);
+                                if (ps.getAttribute('checked') === 'true') {
+                                    ps.setAttribute('checked', 'false');
+                                    document.getElementById('profile-head-title-privacy-private').classList.remove('hidden');
+                                    document.getElementById('profile-head-title-privacy-public').classList.add('hidden');
+                                } else {
+                                    ps.setAttribute('checked', 'true');
+                                    document.getElementById('profile-head-title-privacy-private').classList.add('hidden');
+                                    document.getElementById('profile-head-title-privacy-public').classList.remove('hidden');
+                                }
 
                                 // I hate foundation for making me do this hacky bs to reflow a damn tooltip title. This will probably break with some future foundation release.
                                 let $el = $('#switch-privacy-tooltip');
@@ -73,6 +79,11 @@
                             // });
                         </script>
                     </div>
+                </div>
+                <div class="profile-header-status">
+                    <div id="profile-head-title-privacy"></div>
+                    <div id="profile-head-title-privacy-private" class="profile-head-title-privacy {{#if (eq profile.LookingForWork 1)}}hidden{{/if}}" >Profile: <strong>Private<i class="fas fa-lock"></i></strong></div>
+                    <div id="profile-head-title-privacy-public" class="profile-head-title-privacy {{#if (eq profile.LookingForWork 0)}}hidden{{/if}}">Profile: <strong>Public<i class="fas fa-lock-open"></i></strong></div>
                 </div>
             </div>
         </div>

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -35,12 +35,44 @@
                     <input type="hidden" id="profile-head-title-privacy-value" value="{{profile.LookingForWork}}">
                     <div id="edit-title-privacy-switch" class="switch" hidden>
                         <span>Are you currently looking for a spot in a band?</span><br>
-                        <input class="switch-input" id="privacySwitch" type="checkbox" name="privacySwitch" {{#if profile.LookingForWork}}checked{{/if}}>
-                        <label class="switch-paddle" for="privacySwitch">
-                            <h6 class="show-for-sr">Are you currently looking for a spot in a band?</h6>
-                        </label>
-                    </div>
+                        <span id="switch-privacy-tooltip"
+                              data-tooltip class="top"
+                              tabindex="2"
+                              title="Switching this {{#if profile.LookingForWork}}off{{else}}on{{/if}} will set your profile to {{#if profile.LookingForWork}}private{{else}}public{{/if}} so it will {{#if profile.LookingForWork}}no longer {{/if}}be viewable by other users."
+                              data-position="bottom"
+                              data-alignment="left">
+                            <input class="switch-input" id="privacySwitch" type="checkbox" name="privacySwitch" {{#if profile.LookingForWork}}checked{{/if}}>
+                            <label class="switch-paddle" for="privacySwitch">
+                                <h6 class="show-for-sr">Are you currently looking for a spot in a band?</h6>
+                            </label>
+                        </span>
+                        <script type="text/javascript">
+                            let ps = document.getElementById('privacySwitch');
+                            ps.addEventListener('click', () => {
+                                console.log('privacySwitch', ps);
+                                console.log('privacySwitch clicked! checked ? ', ps.getAttribute('checked'));
+                                ps.setAttribute('checked', ps.getAttribute('checked') ? false : true);
 
+                                // I hate foundation for making me do this hacky bs to reflow a damn tooltip title. This will probably break with some future foundation release.
+                                let $el = $('#switch-privacy-tooltip');
+                                $el.attr('title', `Switching this ${ps.checked ? 'off' : 'on'} will set your profile to ${ps.checked ? 'private' : 'public'} so it will ${ps.checked ? 'no longer ' : ''}be viewable by other users.`);
+                                $el.data().zfPlugin.template.text($el.attr('title'));
+
+                                // If you don't remove the title from the HTML element, then it displays two tooltip hovers because why not.
+                                document.getElementById('switch-privacy-tooltip').setAttribute('title', '');
+                            });
+
+                            // let ps = document.getElementById('privacySwitch');
+                            // ps.addEventListener('click', () => {
+                            //     console.log('privacySwitch clicked! checked ? ', ps.getAttribute('checked'));
+                            //     ps.setAttribute('checked', ps.getAttribute('checked') ? false : true);
+                            //     console.log('tooltip-on: ', document.getElementById('switch-privacy-tooltip-on'));
+                            //     console.log('tooltip-off: ', document.getElementById('switch-privacy-tooltip-off'));
+                            //     document.getElementById('switch-privacy-tooltip-on').hidden = ps.getAttribute('checked') ? false : true;
+                            //     document.getElementById('switch-privacy-tooltip-off').hidden = ps.getAttribute('checked') ? true : false;
+                            // });
+                        </script>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The profile privacy switch now shows a tooltip that lets the user know what happens when they flip the switch. It also changes messaging when the paddle is switched depending on its state. 